### PR TITLE
Fix compilation on Arch Linux

### DIFF
--- a/ast/expression.cpp
+++ b/ast/expression.cpp
@@ -83,8 +83,8 @@ namespace Modelica {
     member_imp(BinOp,BinOpType,op);
     
     IfExp::IfExp () {};
-    IfExp::IfExp (Expression a, Expression b, std::vector<fusion::vector2<Expression, Expression> > elseif, Expression c): cond_(a), then_(b), elseexp_(c) {
-      typedef fusion::vector2<Expression,Expression> P;
+    IfExp::IfExp (Expression a, Expression b, std::vector<boost::fusion::vector2<Expression, Expression> > elseif, Expression c): cond_(a), then_(b), elseexp_(c) {
+      typedef boost::fusion::vector2<Expression,Expression> P;
       foreach_ (P f, elseif) 
         elseif_.push_back(ExpPair(get<0>(f),get<1>(f)));
     };

--- a/ast/expression.h
+++ b/ast/expression.h
@@ -29,8 +29,11 @@
 namespace Modelica {
   namespace AST {
 
-    using namespace boost;
-    
+    using boost::get;
+    using boost::recursive_wrapper;
+    using boost::tuple;
+    using boost::variant;
+
     extern const char *BinOpTypeName[];
     typedef int             Integer;
     typedef double          Real;
@@ -133,7 +136,7 @@ namespace Modelica {
     struct IfExp {
       IfExp ();
       IfExp (Expression a, Expression b, List<ExpPair> elseif, Expression c);
-      IfExp (Expression a, Expression b, std::vector<fusion::vector2<Expression, Expression> > elseif, Expression c);
+      IfExp (Expression a, Expression b, std::vector<boost::fusion::vector2<Expression, Expression> > elseif, Expression c);
       comparable(IfExp);
       printable(IfExp);
       member_(Expression,cond);

--- a/causalize/graph/graph_printer.h
+++ b/causalize/graph/graph_printer.h
@@ -27,7 +27,6 @@
 #include <boost/lexical_cast.hpp>
 
 
-using namespace boost;
 using namespace std;
 using namespace boost::icl;
 #define MAKE_SPACE for(int __i=0; __i<depth; __i++) stri << " ";

--- a/causalize/vector/causalization_algorithm.cpp
+++ b/causalize/vector/causalization_algorithm.cpp
@@ -38,7 +38,6 @@
 
 using namespace Modelica;
 using namespace std;
-using namespace boost;
 using namespace boost::icl;
 
 namespace Causalize {

--- a/causalize/vector/causalization_algorithm.cpp
+++ b/causalize/vector/causalization_algorithm.cpp
@@ -103,7 +103,6 @@ CausalizationStrategyVector::Causalize() {
       return true;
     }
 
-    list<VectorVertex>::size_type numAcausalEqs = equationDescriptors.size();
     list<VectorVertex>::iterator iter, auxiliaryIter;
 
 

--- a/causalize/vector/contains_vector.cpp
+++ b/causalize/vector/contains_vector.cpp
@@ -26,7 +26,6 @@
 #include <util/ast_visitors/partial_eval_expression.h>
 #include <ast/queries.h>
 
-using namespace boost;
 using namespace Modelica;
 using namespace Modelica::AST ;
 

--- a/causalize/vector/graph_builder.cpp
+++ b/causalize/vector/graph_builder.cpp
@@ -37,7 +37,6 @@
 #define DEBUG_MSG(str) do {std::cout << str << std::endl;} while( false )
 
 using namespace std;
-using namespace boost;
 using namespace boost::icl;
 using namespace Modelica;
 using namespace Modelica::AST;

--- a/flatter/flatter.cpp
+++ b/flatter/flatter.cpp
@@ -75,7 +75,7 @@ void Flatter::Flat(MMO_Class &c, bool flatConnector,bool initial)
 					if (down.isConnector()) {
 						c.variables_ref().push_back(n);
 						Type::Class tc = boost::get<Type::Class>(t_final);
-						Name newType = replace_all_copy(v.type(),".","_");
+						Name newType = boost::algorithm::replace_all_copy(v.type(),".","_");
 	                                        c.types_ref().push_back(newType);
         	                                c.tyTable_ref().insert(newType,t_final);
 						v.set_type(newType);

--- a/parser/class_def.h
+++ b/parser/class_def.h
@@ -110,7 +110,7 @@ namespace Modelica
     c.set_annotation(a);
     return c;
   }
-   ClassType add_enc_prefixes(fusion::vector2<bool, ClassPrefixes> a, ClassType c) {
+   ClassType add_enc_prefixes(boost::fusion::vector2<bool, ClassPrefixes> a, ClassType c) {
     const bool &encap = get<0>(a);
     const ClassPrefixes &pre = get<1>(a);
     if (is<Class>(c)) {
@@ -216,9 +216,9 @@ namespace Modelica
       using qi::_4;
       using qi::_5;
       using qi::_val;
-      using phoenix::bind;
-      using phoenix::construct;
-      using phoenix::val;
+      using boost::phoenix::bind;
+      using boost::phoenix::construct;
+      using boost::phoenix::val;
       using qi::fail;
       using qi::on_error;
       using qi::matches;

--- a/parser/equation_def.h
+++ b/parser/equation_def.h
@@ -92,9 +92,9 @@ namespace Modelica
       using qi::_3;
       using qi::_4;
       using qi::_val;
-      using phoenix::bind;
-      using phoenix::construct;
-      using phoenix::val;
+      using boost::phoenix::bind;
+      using boost::phoenix::construct;
+      using boost::phoenix::val;
       using qi::fail;
       using qi::on_error;
       using qi::matches;

--- a/parser/expression_def.h
+++ b/parser/expression_def.h
@@ -217,9 +217,9 @@ namespace Modelica
       using qi::_3;
       using qi::_4;
       using qi::_val;
-      using phoenix::construct;
-      using phoenix::bind;
-      using phoenix::val;
+      using boost::phoenix::construct;
+      using boost::phoenix::bind;
+      using boost::phoenix::val;
       using qi::fail;
       using qi::on_error;
       using qi::lexeme;

--- a/parser/modification_def.h
+++ b/parser/modification_def.h
@@ -228,7 +228,7 @@ namespace Modelica
                                                          REDECLARE("redeclare"), EACH("each"), FINAL("final") {
       using qi::_1;
       using qi::_val;
-      using phoenix::construct;
+      using boost::phoenix::construct;
       using qi::on_error;
       using qi::_2;
       using qi::_3;
@@ -236,10 +236,10 @@ namespace Modelica
       using qi::_5;
       using qi::_6;
       using qi::_7;
-      using phoenix::val;
+      using boost::phoenix::val;
       using qi::fail;
       using qi::matches;
-      using phoenix::bind;
+      using boost::phoenix::bind;
       /*using qi::char_;
       using phoenix::val;
       using qi::fail;

--- a/parser/statement_def.h
+++ b/parser/statement_def.h
@@ -96,9 +96,9 @@ namespace Modelica
       using qi::_3;
       using qi::_4;
       using qi::_val;
-      using phoenix::bind;
-      using phoenix::construct;
-      using phoenix::val;
+      using boost::phoenix::bind;
+      using boost::phoenix::construct;
+      using boost::phoenix::val;
       using qi::fail;
       using qi::on_error;
       using qi::matches;

--- a/util/ast_visitors/constant_expression.cpp
+++ b/util/ast_visitors/constant_expression.cpp
@@ -21,7 +21,6 @@
 
 namespace Modelica {
 
-    using namespace boost;
     ConstantExpression::ConstantExpression() {};
     bool ConstantExpression::operator()(Integer v) const { 
       return true;

--- a/util/ast_visitors/dot_expression.cpp
+++ b/util/ast_visitors/dot_expression.cpp
@@ -23,7 +23,6 @@
 
 namespace Modelica {
 
-    using namespace boost;
     DotExpression::DotExpression(Option<MMO_Class &> m, Name n, ExpList xs): _class(m), prefix(n), index(xs) 
     {
 	if (m)

--- a/util/ast_visitors/eval_expression.cpp
+++ b/util/ast_visitors/eval_expression.cpp
@@ -25,7 +25,6 @@
 
 namespace Modelica {
 
-    using namespace boost;
     EvalExpression::EvalExpression(const VarSymbolTable &v):vtable(v) {};
     EvalExpression::EvalExpression(const VarSymbolTable &v,Name n, Real r):vtable(v),name(n),val(r) {};
     Real EvalExpression::operator()(Integer v) const { 

--- a/util/ast_visitors/partial_eval_expression.cpp
+++ b/util/ast_visitors/partial_eval_expression.cpp
@@ -179,7 +179,7 @@ namespace Modelica {
         foreach_(Expression e, oel.get()) {
           nl.push_back(ApplyThis(e));
         }
-        return Ref(1,RefTuple(s,nl));
+        return Reference(Ref(1,RefTuple(s,nl)));
       }
       return v;
     }

--- a/util/ast_visitors/partial_eval_expression.cpp
+++ b/util/ast_visitors/partial_eval_expression.cpp
@@ -25,7 +25,6 @@
 
 namespace Modelica {
 
-    using namespace boost;
     PartialEvalExpression::PartialEvalExpression(const VarSymbolTable &v, bool eval):vtable(v),eval_parameters(eval) {};
     Expression PartialEvalExpression::operator()(Integer v) const { 
       if (v<0) return Output(v);

--- a/util/ast_visitors/replace_equation.cpp
+++ b/util/ast_visitors/replace_equation.cpp
@@ -22,7 +22,6 @@
 
 namespace Modelica {
 
-    using namespace boost;
     ReplaceEquation::ReplaceEquation(Expression l, Expression r): look(l), rep(r), replace_exp(look,rep) {
       replace_exp.ignoreIndexes();
     };

--- a/util/ast_visitors/replace_expression.cpp
+++ b/util/ast_visitors/replace_expression.cpp
@@ -22,7 +22,6 @@
 
 namespace Modelica {
 
-    using namespace boost;
     ReplaceExpression::ReplaceExpression(Expression l, Expression r): look(l), rep(r), check_indexes(true) {};
     Expression ReplaceExpression::operator()(Integer v) const { 
       if (look==Expression(v))

--- a/util/ast_visitors/replace_statement.cpp
+++ b/util/ast_visitors/replace_statement.cpp
@@ -22,7 +22,6 @@
 
 namespace Modelica {
 
-    using namespace boost;
     ReplaceStatement::ReplaceStatement(Expression l, Expression r): look(l), rep(r), replace_exp(look,rep) {};
     Statement ReplaceStatement::operator()(Break v) const {
       return v;

--- a/util/ast_visitors/splitfor_visitor.cpp
+++ b/util/ast_visitors/splitfor_visitor.cpp
@@ -23,8 +23,6 @@
 
 namespace Modelica {
 
-    using namespace boost;
- 
     EquationList SplitForVisitor::operator()(Connect eq) const {
         return EquationList(1, eq);
     };

--- a/util/ast_visitors/to_micro/convert_to_micro_expression.cpp
+++ b/util/ast_visitors/to_micro/convert_to_micro_expression.cpp
@@ -25,7 +25,6 @@
 
 namespace Modelica {
 
-    using namespace boost;
     ConvertToMicroExpression::ConvertToMicroExpression(MMO_Class &cl, unsigned int &discont, bool w, bool in_alg): mmo_class(cl), 
                                                 disc_count(discont), when(w), in_algorithm(in_alg) {
     };

--- a/util/ast_visitors/to_micro/convert_to_micro_statement.cpp
+++ b/util/ast_visitors/to_micro/convert_to_micro_statement.cpp
@@ -25,7 +25,6 @@
 
 namespace Modelica {
 
-    using namespace boost;
     ConvertToMicroStatement::ConvertToMicroStatement(MMO_Class &cl, unsigned int &discont): mmo_class(cl), disc_count(discont) {
     };
     Statement ConvertToMicroStatement::operator()(Assign v) const { 

--- a/util/solve/solve.cpp
+++ b/util/solve/solve.cpp
@@ -153,7 +153,7 @@ EquationList EquationSolver::Solve(EquationList eqs, ExpList crs, VarSymbolTable
         ret.push_back(Equality(lhs,rhs_exp));
       }
     }
-  } catch (std::logic_error) {    
+  } catch (std::logic_error &) {
     ERROR_UNLESS(!for_eq, "Non linear solving of for loops not suported yet");
     OptExpList ol;
     std::set<Name> args;

--- a/util/type.h
+++ b/util/type.h
@@ -31,7 +31,8 @@ namespace Modelica {
 }
 
 namespace Type {
-    using namespace boost;
+    using boost::variant;
+    using boost::recursive_wrapper;
     using namespace Modelica;
 	typedef std::string     Name;
 	


### PR DESCRIPTION
Arch Linux has a newer GCC (gcc version 8.2.1 20180831 (GCC)) and this was causing modelicacc to not build. I believe some of these issues also impact newer Ubuntu releases (like 18.04).